### PR TITLE
Fix: Order, Receipt 버그 수정

### DIFF
--- a/unicorn/src/components/BreakDown.jsx
+++ b/unicorn/src/components/BreakDown.jsx
@@ -151,7 +151,7 @@ function BreakDownItem({ item, handleRemoveItem, handleDecreaseQuantity, handleI
         <TextBox>
           <ItemName>{item.name}</ItemName>
           <ItemOptionlist>
-            {item.selectedOptions.map((optionGroup, optionIndex) => (
+            {item.selectedOptions.filter(option => option.quantity > 0).map((optionGroup, optionIndex) => (
               <ItemText key={optionIndex}>{optionGroup.name}</ItemText>
             ))}
           </ItemOptionlist>
@@ -171,6 +171,7 @@ function BreakDownItem({ item, handleRemoveItem, handleDecreaseQuantity, handleI
     </BreakItem>
   );
 }
+
 
 function BreakDown({ tableNumber }) {
   const { cart, setCart } = useCartContext();

--- a/unicorn/src/pages/Categories.jsx
+++ b/unicorn/src/pages/Categories.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Header from '../components/Header';
+import styled from 'styled-components';
+
+function Categories(props) {
+    return (
+        <div>
+            카테고리 선택 창입니다.
+        </div>
+    );
+}
+
+export default Categories;

--- a/unicorn/src/pages/Order.jsx
+++ b/unicorn/src/pages/Order.jsx
@@ -32,7 +32,7 @@ export default function Order() {
 
     const HandleCart = () => {
         console.log("cart", cart);
-        navigate('/receipt');
+        navigate('receipt');
     }
 
     return (


### PR DESCRIPTION
- Order PAGE > Receipt 페이지 전환 시, 절대 경로로 지정된 `navigate('/receipt');`을 상대경로 `navigate('receipt');` 로 변경
- Receipt 페이지에서 수량이 0인 추가 옵션 미출력 되도록 변경 `{item.selectedOptions.filter(option => option.quantity > 0).map` 필터링 추가